### PR TITLE
fix ansible_managed field in templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,4 @@ rsyslog_server_tcp_port: "514"
 rsyslog_server_tcp_address: "0.0.0.0"
 rsyslog_server_tcp_ratelimit: "5"
 rsyslog_os_supported: no
+rsyslog_max_message_size: 8k

--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -13,6 +13,7 @@ $ActionFileDefaultTemplate {{ rsyslog_action_file_default_template }}
 
 $AbortOnUncleanConfig {{ rsyslog_abort_on_unclean_config | default('off') }}
 $RepeatedMsgReduction {{ rsyslog_repeated_msg_reduction | default('off') }}
+$PreserveFQDN {{ rsyslog_preserve_fqdn | default('on') }}
 
 $FileOwner {{ rsyslog_file_owner }}
 $FileGroup {{ rsyslog_file_group }}

--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -4,6 +4,9 @@ $ModLoad immark.so
 $ModLoad imuxsock.so
 $ModLoad imklog.so
 
+{% if rsyslog_max_message_size is defined %}
+$MaxMessageSize {{ rsyslog_max_message_size }}
+{% endif %}
 {% if rsyslog_action_file_template %}
 $ActionFileDefaultTemplate myFormat
 $template myFormat,{{ rsyslog_action_file_template }}

--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -1,4 +1,4 @@
-## {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 $ModLoad immark.so
 $ModLoad imuxsock.so

--- a/templates/rsyslog.snippet.conf.j2
+++ b/templates/rsyslog.snippet.conf.j2
@@ -1,4 +1,4 @@
-## {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for line in item.lines %}
 {{ line }}

--- a/templates/rsyslog.yum.repo.j2
+++ b/templates/rsyslog.yum.repo.j2
@@ -1,4 +1,4 @@
-## {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [rsyslog_{{ repo_releasever }}]
 name=Adiscon CentOS-{{ ansible_distribution_major_version }} - local packages for {{ ansible_architecture }}


### PR DESCRIPTION
I use multiline ansible_managed record. Your role add something like this:

```
## This file is managed by Ansible.

template: /home/sprokhorov/ansible/roles/rsyslog/templates/rsyslog.snippet.conf.j2
date: 2017-03-16 13:20:12
user: sprokhorov
host: ansible1.example.com
```


This commit fix it to:

```
#
# This file is managed by Ansible.
#
# template: `/home/sprokhorov/ansible/roles/rsyslog/templates/rsyslog.snippet.conf.j2`
# date: 2017-03-16 13:20:12
# user: sprokhorov
# host: ansible1.example.com
#
```