### PR TITLE
Fix parsing error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,7 +76,7 @@
         - 'cron.*                                   -/var/log/cron.log'
         - 'mail.*                                   -/var/log/mail.log'
         - 'uucp,news.*                              /var/log/spooler'
-        - '*.emerg                                  *'
+        - '*.emerg                                  /*'
         - 'local7.*                                 /var/log/boot.log'
         - '*.*                                      /var/log/uncategorized.log'
   notify:


### PR DESCRIPTION
Without a `/` it results in the following error:
Mar 02 09:27:07 centos7.sean.example.com rsyslogd[2844]: error during parsing file /etc/rsyslog.d/50-default.conf, on or before line 10: warnings occured in file '/etc/rsyslog.d/50-default.conf' around line 10 [v8.24.0 try http://www.rsyslog.com/e/2207 ]